### PR TITLE
Add Supabase auth bootstrap and magic link UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+supabase-config.js

--- a/app.js
+++ b/app.js
@@ -1,0 +1,177 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const config = window.supabaseConfig || {};
+
+if (!config.supabaseUrl || !config.supabaseAnonKey) {
+  console.warn(
+    "Supabase configuration is missing. Create a supabase-config.js file based on supabase-config.example.js."
+  );
+}
+
+export const supabase =
+  config.supabaseUrl && config.supabaseAnonKey
+    ? createClient(config.supabaseUrl, config.supabaseAnonKey, {
+        auth: {
+          persistSession: true,
+        },
+      })
+    : null;
+
+window.supabase = supabase;
+
+const modal = document.getElementById("auth-modal");
+const form = document.getElementById("magic-link-form");
+const emailInput = document.getElementById("auth-email-input");
+const submitButton = document.getElementById("magic-link-submit");
+const messageEl = document.getElementById("auth-message");
+const authEmail = document.getElementById("auth-email");
+const signOutButton = document.getElementById("sign-out-button");
+const openButtons = document.querySelectorAll('[data-action="open-auth"]');
+const closeElements = document.querySelectorAll('[data-action="close-auth"]');
+
+function setMessage(text = "", status) {
+  if (!messageEl) return;
+  if (status) {
+    messageEl.dataset.status = status;
+  } else {
+    delete messageEl.dataset.status;
+  }
+  messageEl.textContent = text;
+}
+
+function openAuthModal() {
+  if (!modal) return;
+  modal.classList.add("is-open");
+  modal.setAttribute("aria-hidden", "false");
+  setMessage();
+  if (emailInput) {
+    emailInput.focus();
+  }
+}
+
+function closeAuthModal() {
+  if (!modal) return;
+  modal.classList.remove("is-open");
+  modal.setAttribute("aria-hidden", "true");
+  form?.reset();
+  setMessage();
+}
+
+function renderAuthState(session) {
+  const state = session ? "signed-in" : "signed-out";
+  document.body.dataset.auth = state;
+  if (authEmail) {
+    authEmail.textContent = session?.user?.email || "";
+  }
+}
+
+async function handleMagicLinkSubmit(event) {
+  event.preventDefault();
+  if (!form || !emailInput || !submitButton) return;
+
+  const email = emailInput.value.trim();
+  if (!email) {
+    setMessage("Please enter your email address.", "error");
+    return;
+  }
+
+  if (!supabase) {
+    setMessage("Supabase is not configured for this environment.", "error");
+    return;
+  }
+
+  submitButton.disabled = true;
+  setMessage("Sending magic link...");
+
+  try {
+    const { error } = await supabase.auth.signInWithOtp({ email });
+    if (error) {
+      throw error;
+    }
+    setMessage("Check your email for the sign-in link.", "success");
+    form.reset();
+    setTimeout(() => {
+      closeAuthModal();
+    }, 1600);
+  } catch (error) {
+    console.error("Failed to send magic link", error);
+    setMessage(error.message || "We could not send the magic link. Please try again.", "error");
+  } finally {
+    submitButton.disabled = false;
+  }
+}
+
+async function handleSignOut() {
+  if (!supabase || !signOutButton) return;
+  signOutButton.disabled = true;
+  try {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      throw error;
+    }
+    setMessage("You have been signed out.", "success");
+  } catch (error) {
+    console.error("Failed to sign out", error);
+    setMessage(error.message || "Unable to sign out.", "error");
+  } finally {
+    signOutButton.disabled = false;
+  }
+}
+
+function attachEventListeners() {
+  openButtons.forEach((button) => {
+    button.addEventListener("click", openAuthModal);
+  });
+
+  closeElements.forEach((el) => {
+    el.addEventListener("click", closeAuthModal);
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && modal?.classList.contains("is-open")) {
+      closeAuthModal();
+    }
+  });
+
+  form?.addEventListener("submit", handleMagicLinkSubmit);
+  signOutButton?.addEventListener("click", handleSignOut);
+}
+
+async function initialiseSession() {
+  if (!supabase) {
+    renderAuthState(null);
+    return;
+  }
+
+  try {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    renderAuthState(session);
+  } catch (error) {
+    console.error("Failed to fetch session", error);
+    renderAuthState(null);
+  }
+
+  supabase.auth.onAuthStateChange((_event, session) => {
+    renderAuthState(session);
+  });
+}
+
+function init() {
+  if (!document.body.dataset.auth) {
+    document.body.dataset.auth = "signed-out";
+  }
+
+  renderAuthState(null);
+  attachEventListeners();
+  initialiseSession();
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init, { once: true });
+} else {
+  init();
+}
+
+export { openAuthModal, closeAuthModal };

--- a/index.html
+++ b/index.html
@@ -12,18 +12,41 @@
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
-  <body>
+  <body data-auth="signed-out">
     <header class="site-header">
       <div class="container">
         <div class="logo">WriterCoach</div>
-        <nav class="site-nav">
-          <a href="#overview">Overview</a>
-          <a href="#workflow">Workflow</a>
-          <a href="#progress">Progress views</a>
-          <a href="#digest">LLM digest</a>
-          <a href="#roadmap">Roadmap</a>
-          <a href="#contact">Get involved</a>
-        </nav>
+        <div class="header-right">
+          <nav class="site-nav">
+            <a href="#overview">Overview</a>
+            <a href="#workflow">Workflow</a>
+            <a href="#progress">Progress views</a>
+            <a href="#digest">LLM digest</a>
+            <a href="#roadmap">Roadmap</a>
+            <a href="#contact">Get involved</a>
+          </nav>
+          <div class="auth-controls">
+            <div class="auth-badge" data-auth-visible="signed-in">
+              Signed in as <span id="auth-email"></span>
+            </div>
+            <button
+              class="button tertiary"
+              type="button"
+              data-action="open-auth"
+              data-auth-visible="signed-out"
+            >
+              Sign in
+            </button>
+            <button
+              class="button tertiary"
+              type="button"
+              id="sign-out-button"
+              data-auth-visible="signed-in"
+            >
+              Sign out
+            </button>
+          </div>
+        </div>
       </div>
     </header>
 
@@ -250,12 +273,49 @@
       </section>
     </main>
 
+    <div id="auth-modal" class="auth-modal" aria-hidden="true">
+      <div class="auth-modal__backdrop" data-action="close-auth"></div>
+      <div
+        class="auth-modal__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="auth-modal-title"
+      >
+        <button
+          class="auth-modal__close"
+          type="button"
+          data-action="close-auth"
+          aria-label="Close sign-in form"
+        >&times;</button>
+        <h2 id="auth-modal-title">Sign in with a magic link</h2>
+        <p>Enter your email address and we will send you a secure sign-in link.</p>
+        <form id="magic-link-form" class="auth-form">
+          <div class="form-group">
+            <label for="auth-email-input">Email</label>
+            <input
+              id="auth-email-input"
+              name="email"
+              type="email"
+              placeholder="you@example.com"
+              required
+            />
+          </div>
+          <button class="button primary" type="submit" id="magic-link-submit">
+            Send magic link
+          </button>
+        </form>
+        <p class="auth-message" id="auth-message" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+
     <footer class="site-footer">
       <div class="container">
         <p>&copy; <span id="year"></span> WriterCoach. Built for ESL writing growth.</p>
       </div>
     </footer>
 
+    <script src="supabase-config.js"></script>
+    <script type="module" src="app.js"></script>
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();
     </script>

--- a/styles.css
+++ b/styles.css
@@ -63,6 +63,12 @@ a {
   padding: 1rem 0;
 }
 
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
 .logo {
   font-weight: 700;
   font-size: 1.25rem;
@@ -82,6 +88,44 @@ a {
 
 .site-nav a:hover {
   color: #fff;
+}
+
+.auth-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.button.tertiary {
+  background: rgba(15, 23, 42, 0.15);
+  color: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: none;
+}
+
+.button.tertiary:hover {
+  background: rgba(15, 23, 42, 0.3);
+}
+
+.auth-badge {
+  background: rgba(15, 23, 42, 0.2);
+  color: rgba(226, 232, 240, 0.9);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+[data-auth-visible] {
+  display: none !important;
+}
+
+body[data-auth="signed-out"] [data-auth-visible="signed-out"],
+body[data-auth="signed-in"] [data-auth-visible="signed-in"] {
+  display: inline-flex !important;
 }
 
 .hero {
@@ -360,6 +404,80 @@ textarea:focus {
   outline-offset: 2px;
 }
 
+.auth-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(6px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 20;
+}
+
+.auth-modal.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.auth-modal__backdrop {
+  position: absolute;
+  inset: 0;
+}
+
+.auth-modal__panel {
+  position: relative;
+  background: var(--surface);
+  padding: 2.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.25);
+  width: min(420px, 92vw);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.auth-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.auth-modal__close:hover {
+  color: var(--accent-dark);
+}
+
+.auth-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-message {
+  min-height: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.auth-message[data-status="success"] {
+  color: #0f766e;
+}
+
+.auth-message[data-status="error"] {
+  color: #b91c1c;
+}
+
 .site-footer {
   background: var(--bg-alt);
   color: rgba(226, 232, 240, 0.85);
@@ -371,6 +489,14 @@ textarea:focus {
 @media (max-width: 640px) {
   .site-nav {
     display: none;
+  }
+
+  .header-right {
+    justify-content: flex-end;
+  }
+
+  .auth-controls {
+    gap: 0.5rem;
   }
 
   .hero-card {

--- a/supabase-config.example.js
+++ b/supabase-config.example.js
@@ -1,0 +1,4 @@
+window.supabaseConfig = {
+  supabaseUrl: "https://your-project.supabase.co",
+  supabaseAnonKey: "public-anon-key",
+};


### PR DESCRIPTION
## Summary
- add header controls and modal markup for Supabase magic-link sign in/out
- bootstrap the Supabase client and session handlers in a new app.js module
- provide a supabase-config example and ignore the real config file

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da8bcbbe7c8333aafb18738548b30f